### PR TITLE
Allow admin to delete post

### DIFF
--- a/src/controllers/postController.js
+++ b/src/controllers/postController.js
@@ -201,14 +201,19 @@ const deletePost = async (req, res) => {
         .json({ message: 'Post not found' });
     }
 
-    // Verify if the authenticated user is the post's author
-    if (post.author.toString() !== req.user.id) {
-      return res
-        .status(StatusCodes.UNAUTHORIZED)
-        .json({ message: 'Unauthorized to delete this post' });
-    }
+    // Only admin and the author of the post can delete post
+    if (req.user.role === 'admin') {
+      await Post.findByIdAndDelete(req.params.id);
+    } else {
+      // Verify if the authenticated user is the post's author
+      if (post.author.toString() !== req.user.id) {
+        return res
+          .status(StatusCodes.UNAUTHORIZED)
+          .json({ message: 'Unauthorized to delete this post' });
+      }
 
-    await Post.findByIdAndDelete(req.params.id);
+      await Post.findByIdAndDelete(req.params.id);
+    }
 
     res.status(StatusCodes.OK).json({ message: 'Post deleted' });
   } catch (error) {


### PR DESCRIPTION
In the previous delete Post, only the user who wrote the post can delete the post.

Now, change it so an admin can delete Post as well 

Login as admin 
![Login as admin](https://github.com/user-attachments/assets/1e518272-dc66-46f7-868e-f01258f199d7)
Delete any Post as a admin 
![Delete as admin](https://github.com/user-attachments/assets/f1932590-c344-427c-a353-6d7c875b670e)
